### PR TITLE
feat(useSortable): Add possibility to use it with Component ref

### DIFF
--- a/packages/integrations/useSortable/index.ts
+++ b/packages/integrations/useSortable/index.ts
@@ -1,6 +1,6 @@
 import type { ConfigurableDocument } from '@vueuse/core'
 import type { Options } from 'sortablejs'
-import type { MaybeRef, MaybeRefOrGetter } from 'vue'
+import type { ComponentPublicInstance, MaybeRef, MaybeRefOrGetter } from 'vue'
 import { defaultDocument, tryOnMounted, tryOnScopeDispose, unrefElement } from '@vueuse/core'
 import Sortable from 'sortablejs'
 import { isRef, nextTick, toValue } from 'vue'
@@ -27,7 +27,7 @@ export type UseSortableOptions = Options & ConfigurableDocument
 
 export function useSortable<T>(selector: string, list: MaybeRefOrGetter<T[]>,
   options?: UseSortableOptions): UseSortableReturn
-export function useSortable<T>(el: MaybeRefOrGetter<HTMLElement | null | undefined>, list: MaybeRefOrGetter<T[]>,
+export function useSortable<T>(el: MaybeRefOrGetter<HTMLElement | ComponentPublicInstance | null | undefined>, list: MaybeRefOrGetter<T[]>,
   options?: UseSortableOptions): UseSortableReturn
 
 /**
@@ -37,7 +37,7 @@ export function useSortable<T>(el: MaybeRefOrGetter<HTMLElement | null | undefin
  * @param options
  */
 export function useSortable<T>(
-  el: MaybeRefOrGetter<HTMLElement | null | undefined> | string,
+  el: MaybeRefOrGetter<HTMLElement | ComponentPublicInstance | null | undefined> | string,
   list: MaybeRefOrGetter<T[]>,
   options: UseSortableOptions = {},
 ): UseSortableReturn {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR allows the `useSortable` to be used when the ref is a component instead of a html element. E.G:

```
 <CGallery ref="gallery"
                  v-model="imageUrls"
                  is-deletable
        />

const imageUrls = ref<string[]>({ required: true });

const gallery = useTemplateRef<ComponentPublicInstance>('gallery');

useSortable(gallery, imageUrls, { animation: 200 });

```


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the sortable functionality to support Vue component instances as well as standard HTML elements, offering improved flexibility and compatibility for Vue applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->